### PR TITLE
Use safe existence check for jsvars with -v

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A sample HTML file is provided in the [`private4Debug/test.html`](private4Debug/
 This file was captured from [spys.one](https://spys.one), a public proxy listing service that embeds proxy IPs and obfuscated ports using JavaScript expressions.
 
 ## Requirements
-- Bash 4+
+- Bash 4.2+
 - Standard GNU tools: `grep`, `head`, `tr`, `printf`
 
 ## Installation

--- a/find_proxies.sh
+++ b/find_proxies.sh
@@ -17,8 +17,12 @@ Options:
 EOF
 }
 
-# Require Bash 4+
-[[ ${BASH_VERSINFO[0]} -lt 4 ]] && { echo "Error: Bash 4+ required" >&2; exit 1; }
+# Require Bash 4.2+
+if (( BASH_VERSINFO[0] < 4 )) \
+   || (( BASH_VERSINFO[0] == 4 && BASH_VERSINFO[1] < 2 )); then
+  echo "Error: Bash 4.2 or newer required" >&2
+  exit 1
+fi
 
 # Strict IPv4 regex: each octet 0–255
 readonly strict_ip_regex='^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$'
@@ -73,9 +77,9 @@ while IFS= read -r line; do
     lit="${BASH_REMATCH[2]}"
     ref="${BASH_REMATCH[3]}"
     if $verbose; then
-	echo "processing $line" >&2
+	    echo "processing $line" >&2
     fi
-    if [[ -n "${jsvars[$ref]}" ]]; then
+    if [[ -v jsvars[$ref] ]]; then
       jsvars["$localname"]=$(( lit ^ jsvars[$ref] ))
     fi
   fi


### PR DESCRIPTION
Replace unsafe -n test on jsvars[$ref] with [[ -v jsvars[$ref] ]]
Adjust runtime check and update README to require Bash 4.2+ due to use
of -v operator.
Fixes #2